### PR TITLE
Fix negative nps

### DIFF
--- a/src/uci.cc
+++ b/src/uci.cc
@@ -198,7 +198,7 @@ void Info::clear()
     clock.reset();
 }
 
-void Info::update(const Position& pos, int depth, int score, int nodes, std::vector<move_t>& pv,
+void Info::update(const Position& pos, int depth, int score, uint64_t nodes, std::vector<move_t>& pv,
                   bool partial)
 {
     std::lock_guard<std::mutex> lk(mtx);

--- a/src/uci.h
+++ b/src/uci.h
@@ -11,7 +11,7 @@ void loop();
 class Info {
 public:
     void clear();
-    void update(const Position& pos, int depth, int score, int nodes, std::vector<move_t>& pv,
+    void update(const Position& pos, int depth, int score, uint64_t nodes, std::vector<move_t>& pv,
                 bool partial = false);
     void print_bestmove(const Position& pos) const;
 


### PR DESCRIPTION
The engine reported negative nps from time to time. 

Try for example

./demolitio search 15 1

Here is the result for the second bench position:
before:

r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0
info depth 1 score cp 127 time 1 nodes 169 nps 169000 pv e2a6 b4c3
info depth 2 score cp 127 time 1 nodes 272 nps 272000 pv e2a6 b4c3
info depth 3 score cp 85 time 1 nodes 1089 nps 1089000 pv e2a6 h3g2 f3g2
info depth 4 score cp 78 time 2 nodes 2002 nps 1001000 pv e2a6 b4c3 d2c3 h3g2
info depth 5 score cp 78 time 4 nodes 5925 nps 1481250 pv e2a6 b4c3 d2c3 h3g2 f3g2
info depth 6 score cp 34 time 7 nodes 12349 nps 1764142 pv e2a6 b4c3 d2c3 e6d5 a6b7 h3g2
info depth 7 score cp 34 time 14 nodes 27545 nps 1967500 pv e2a6 b4c3 d2c3 e6d5 a6b7 h3g2 f3g2
info depth 8 score cp -7 time 30 nodes 62072 nps 2069066 pv e2a6 b4c3 d2c3 e6d5 a6b7 d5e4 f3g3 h3g2
info depth 9 score cp -7 time 52 nodes 114165 nps 2195480 pv e2a6 b4c3 d2c3 e6d5 a6b7 d5e4 f3g3 h3g2 g3g2
info depth 10 score cp -12 time 108 nodes 242466 nps 2245055 pv e2a6 b4c3 d2c3 e6d5 e5g4 h3g2 f3g2 d5e4 g4f6 g7f6 c3f6
info depth 11 score cp -36 time 426 nodes 995340 nps 2336478 pv e2a6 e6d5 c3b5 e7e5 d2f4 e5b2 b5c7 e8d8 e1g1 d5e4 f3g3 h3g2
info depth 12 score cp -42 time 703 nodes 1636604 nps 2328028 pv e2a6 e6d5 c3b5 e7e5 d2f4 e5b2 b5c7 e8f8 e1g1 d5e4 f3e3 h3g2 g1g2
info depth 13 score cp -29 time 1533 nodes 3652756 nps -418924 pv e2a6 b4c3 d2c3 e6d5 e5g4 h3g2 f3g2 h8h4 g4e3 e7e4 e1c1 e4g2 e3g2
info depth 14 score cp -62 time 6227 nodes 15071720 nps -338549 pv d5e6 e7e6 e2a6 h3g2 f3g2 e6e5 a6b7 b4c3 d2c3 e5f4 b7a8 b6a8 a1d1 a8b6
info depth 15 score cp -46 time 20378 nodes 50037512 nps -73711 pv d5e6 e7e6 e2a6 e6e5 d2f4 e5e6 c3b5 b6d5 f4c7 f6e4 e1c1 h3g2 f3g2 e8g8 c1b1
bestmove d5e6 ponder e7e6


after:
r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0
info depth 1 score cp 127 time 1 nodes 169 nps 169000 pv e2a6 b4c3
info depth 2 score cp 127 time 1 nodes 272 nps 272000 pv e2a6 b4c3
info depth 3 score cp 85 time 1 nodes 1089 nps 1089000 pv e2a6 h3g2 f3g2
info depth 4 score cp 78 time 2 nodes 2002 nps 1001000 pv e2a6 b4c3 d2c3 h3g2
info depth 5 score cp 78 time 4 nodes 5925 nps 1481250 pv e2a6 b4c3 d2c3 h3g2 f3g2
info depth 6 score cp 34 time 7 nodes 12349 nps 1764142 pv e2a6 b4c3 d2c3 e6d5 a6b7 h3g2
info depth 7 score cp 34 time 13 nodes 27545 nps 2118846 pv e2a6 b4c3 d2c3 e6d5 a6b7 h3g2 f3g2
info depth 8 score cp -7 time 29 nodes 62072 nps 2140413 pv e2a6 b4c3 d2c3 e6d5 a6b7 d5e4 f3g3 h3g2
info depth 9 score cp -7 time 52 nodes 114165 nps 2195480 pv e2a6 b4c3 d2c3 e6d5 a6b7 d5e4 f3g3 h3g2 g3g2
info depth 10 score cp -12 time 108 nodes 242466 nps 2245055 pv e2a6 b4c3 d2c3 e6d5 e5g4 h3g2 f3g2 d5e4 g4f6 g7f6 c3f6
info depth 11 score cp -36 time 429 nodes 995340 nps 2320139 pv e2a6 e6d5 c3b5 e7e5 d2f4 e5b2 b5c7 e8d8 e1g1 d5e4 f3g3 h3g2
info depth 12 score cp -42 time 703 nodes 1636604 nps 2328028 pv e2a6 e6d5 c3b5 e7e5 d2f4 e5b2 b5c7 e8f8 e1g1 d5e4 f3e3 h3g2 g1g2
info depth 13 score cp -29 time 1539 nodes 3652756 nps 2373460 pv e2a6 b4c3 d2c3 e6d5 e5g4 h3g2 f3g2 h8h4 g4e3 e7e4 e1c1 e4g2 e3g2
info depth 14 score cp -62 time 6253 nodes 15071720 nps 2410318 pv d5e6 e7e6 e2a6 h3g2 f3g2 e6e5 a6b7 b4c3 d2c3 e5f4 b7a8 b6a8 a1d1 a8b6
info depth 15 score cp -46 time 20710 nodes 50037512 nps 2416103 pv d5e6 e7e6 e2a6 e6e5 d2f4 e5e6 c3b5 b6d5 f4c7 f6e4 e1c1 h3g2 f3g2 e8g8 c1b1
bestmove d5e6 ponder e7e6
