### PR TITLE
Remove constant in reduction formula (14699098)

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -47,7 +47,7 @@ void search_init()
 {
     for (int d = 1; d <= MAX_DEPTH; d++)
         for (int cnt = 1; cnt < MAX_MOVES; cnt++)
-            Reduction[d][cnt] = 0.4 * log(d > 31 ? 31 : d) + 1.057 * log(min(cnt, 31)) + 0.047;
+            Reduction[d][cnt] = 0.4 * log(d > 31 ? 31 : d) + 1.057 * log(min(cnt, 31));
 }
 
 static const int Tempo = 17;


### PR DESCRIPTION
sprt(0,5), tc=8+0.08, hash=8:
LLR: 2.98 (-2.94, 2.94) [0.00, 5.00]
Games: 47724 W: 12089 L: 11694 D: 23941

sprt(0,5), tc=32+0.32, hash=32:
LLR: 2.96 (-2.94, 2.94) [0.00, 5.00]
Games: 24815 W: 5346 L: 5097 D: 14372